### PR TITLE
delete arabic.dart

### DIFF
--- a/arabic.dart
+++ b/arabic.dart
@@ -1,7 +1,0 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-import 'package:flutter/widgets.dart';
-
-void main() => runApp(const Center(child: Text('برنامج أهلا بالعالم', textDirection: TextDirection.rtl)));


### PR DESCRIPTION
arabic.dart is deleted because that is a unnecessary file.