### PR TITLE
delete unnecessary import

### DIFF
--- a/lib/src/features/rate/rate.dart
+++ b/lib/src/features/rate/rate.dart
@@ -1,10 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'page1.dart';
-import 'page2.dart';
-import 'page3.dart';
-import 'page4.dart';
-
 class RateScreen extends StatelessWidget {
   RateScreen({Key? key}) : super(key: key);
 


### PR DESCRIPTION
"import page1.dart", "import page2.dart", "import page3.dart", "import page4.dart", are deleted by reasons of false names and unnecessary files.